### PR TITLE
Pin scipy to a stable version due to import issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     install_requires=[
         "numpy",
         "treelib>=1.6",
-        "scipy",
+        "scipy==1.15",
         "scikit-learn",
         "statsmodels>=0.13",
         "kdepy",


### PR DESCRIPTION
As of June 23, 2025, the latest scipy release has a critical import issue (see [statsmodels/statsmodels#9584](https://github.com/statsmodels/statsmodels/issues/9584)). Temporarily pinning scipy to a healthy version until the upstream problem is resolved.